### PR TITLE
General: Add Vscode configuration to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,6 @@ dmypy.json
 
 db.sqlite3
 
+# IDE configuration
 .idea
+.vscode


### PR DESCRIPTION
ignore .vscode folder when using git

* I configured `black` as my python formatter and configured it to be max-line of 120 in my vscode configuration