### PR TITLE
Tests: Adjust views and form tests to use Django's client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,6 @@ import pytest
 from django.utils import timezone
 from house.models import House, City, Country
 from expenses.models import Expenses
-from factories.house import HouseFactory
-from django.test.client import RequestFactory
-from house.forms import HouseIDForm
 
 HOUSE_NAME = "House 1"
 HOUSE_PUBLIC = True
@@ -17,8 +14,6 @@ HOUSE_DESCRIPTION = "description"
 EXPENSE_AMOUNT = 100
 EXPENSE_DATE = timezone.now()
 EXPENSE_CATEGORY = Expenses.Category.CLOTHING
-
-BAD_FORM_DATA = {'house_id': '1234'}
 
 
 @pytest.fixture
@@ -42,30 +37,3 @@ def generate_expense(db, generate_house):
     return Expenses.create_expense(
         house_name=generate_house, amount=EXPENSE_AMOUNT, date=EXPENSE_DATE, category=EXPENSE_CATEGORY
     )
-
-
-@pytest.fixture
-def request_factory():
-    return RequestFactory()
-
-
-@pytest.fixture
-def generate_get_request(request_factory):
-    get_request = request_factory.get('login/')
-    return get_request
-
-
-@pytest.fixture
-def generate_form(request_factory):
-    HouseFactory().save()
-    house = House.objects.all()[0]
-    post_request = request_factory.post('login/', {'house_id': f'{house.house_id}'})
-    form = HouseIDForm(post_request.POST)
-    return form
-
-
-@pytest.fixture
-def generate_bad_form(request_factory):
-    post_request = request_factory.post('login/', BAD_FORM_DATA)
-    form = HouseIDForm(post_request.POST)
-    return form

--- a/tests/global_page_tests.py
+++ b/tests/global_page_tests.py
@@ -1,20 +1,6 @@
-import pytest
 from django.template import TemplateDoesNotExist
-from django.test.client import RequestFactory
 from house.constants import GLOBAL_PAGE_ROUTE
 from django.template.loader import get_template
-from house.views import global_page
-
-
-@pytest.fixture
-def request_factory():
-    return RequestFactory()
-
-
-@pytest.fixture
-def generate_get_request(request_factory):
-    get_request = request_factory.get('global/')
-    return get_request
 
 
 class TestGlobalPage:
@@ -24,9 +10,6 @@ class TestGlobalPage:
         except TemplateDoesNotExist:
             assert False, f"Template {GLOBAL_PAGE_ROUTE} does not exist"
 
-    def test_global_function_200(self, db, generate_get_request):
-        try:
-            render = global_page(generate_get_request)
-            assert render.status_code == 200, "Status code is not 200"
-        except Exception:
-            assert False, "Error in global_page function"
+    def test_global_function_200(self, db, client):
+        render = client.get('/global/')
+        assert render.status_code == 200, "Status code is not 200"

--- a/tests/house_login_page_tests.py
+++ b/tests/house_login_page_tests.py
@@ -1,9 +1,7 @@
 import pytest
 from house.constants import LOGIN_PAGE_ROUTE
-from house.views import house_login
 from house.models import House
 from factories.house import HouseFactory
-from django.test.client import RequestFactory
 from house.forms import HouseIDForm
 from django.template.loader import get_template
 from django.template import TemplateDoesNotExist
@@ -12,29 +10,17 @@ BAD_FORM_DATA = {'house_id': '1234'}
 
 
 @pytest.fixture
-def request_factory():
-    return RequestFactory()
-
-
-@pytest.fixture
-def generate_get_request(request_factory):
-    get_request = request_factory.get('login/')
-    return get_request
-
-
-@pytest.fixture
-def generate_form(request_factory):
+def generate_form():
     HouseFactory().save()
     house = House.objects.all()[0]
-    post_request = request_factory.post('login/', {'house_id': f'{house.house_id}'})
-    form = HouseIDForm(post_request.POST)
+    form_data = {'house_id': str(house.house_id)}
+    form = HouseIDForm(form_data)
     return form
 
 
 @pytest.fixture
-def generate_bad_form(request_factory):
-    post_request = request_factory.post('login/', BAD_FORM_DATA)
-    form = HouseIDForm(post_request.POST)
+def generate_bad_form():
+    form = HouseIDForm(BAD_FORM_DATA)
     return form
 
 
@@ -46,9 +32,9 @@ class TestLoginViews:
         except TemplateDoesNotExist:
             assert False, f"Template {LOGIN_PAGE_ROUTE} does not exist"
 
-    def test_login_page_function_200(self, generate_get_request):
+    def test_login_page_function_200(self, client):
         try:
-            render = house_login(generate_get_request)
+            render = client.get('/login/')
             assert render.status_code == 200, "status code is not 200"
         except Exception:
             assert False, "Error in house_login function"

--- a/tests/house_tests.py
+++ b/tests/house_tests.py
@@ -6,7 +6,6 @@ from django.template.loader import get_template
 from django.template import TemplateDoesNotExist
 from house.constants import MINE_EXPENSES_TITLE_ROUTE, MINE_HOUSE_TABLE_ROUTE, MINE_HOUSE_TABLE_TITLE_ROUTE
 from house.constants import MINE_MINE_PAGE_ROUTE, MINE_SIDEBAR_ROUTE
-from house.views import house_view
 
 
 @pytest.mark.django_db
@@ -108,11 +107,11 @@ def form_data_filter_tests():
 
 @pytest.mark.django_db
 class TestMyHouseViews:
-    def test_house_view_function_200(self, db, generate_get_request):
+    def test_house_view_function_200(self, client):
         HouseFactory().save()
         house = House.objects.all()[0]
         try:
-            render = house_view(generate_get_request, house.house_id)
+            render = client.get('/house/' + str(house.house_id) + '/')
             assert render.status_code == 200, "Status code is not 200"
         except Exception:
             assert False, "Error in house_view function"

--- a/tests/tips_views_tests.py
+++ b/tests/tips_views_tests.py
@@ -3,19 +3,19 @@ from django.utils import timezone
 from django.shortcuts import get_object_or_404
 from tips.models import Tip
 from django.template import TemplateDoesNotExist
-from django.test.client import RequestFactory
 from tips.forms import TipForm
-from tips.views import board, delete_tip
 from django.template.loader import get_template
 from tips.constants import TIPS_PAGE_ROUTE, ADD_TIP_PAGE_ROUTE, EDIT_TIP_PAGE_ROUTE
 
 AUTHOR = 'RICK'
 OTHER_AUTHOR = 'RICKEN'
 CATEGORY = 'Clothing'
+OTHER_CATEGORY = 'Food'
 DATE = timezone.now()
 TEXT = 'I BOUGHT A TESLA IN 50$ DISCOUNT IN LEVINSKI MARKET'
+OTHER_TEXT = 'Let them eat cake'
 
-FORM_DATA = {'author': OTHER_AUTHOR, 'text': TEXT, 'category': CATEGORY}
+FORM_DATA = {'author': OTHER_AUTHOR, 'text': OTHER_TEXT, 'category': OTHER_CATEGORY}
 BAD_FORM_DATA = {'author': OTHER_AUTHOR, 'text': '', 'category': CATEGORY}
 
 
@@ -30,36 +30,20 @@ def generate_tip():
 
 
 @pytest.fixture
-def request_factory():
-    return RequestFactory()
-
-
-@pytest.fixture
-def generate_form(request_factory):
-    post_request = request_factory.post(
-        'tips/add_tip',
-        FORM_DATA,
-    )
-    form = TipForm(post_request.POST)
+def generate_form():
+    form = TipForm(FORM_DATA)
     return form
 
 
 @pytest.fixture
-def generate_bad_form(request_factory):
-    post_request = request_factory.post('tips/add_tip', BAD_FORM_DATA)
-    form = TipForm(post_request.POST)
+def generate_bad_form():
+    form = TipForm(BAD_FORM_DATA)
     return form
-
-
-@pytest.fixture
-def generate_get_request(request_factory):
-    get_request = request_factory.get('tips/')
-    return get_request
 
 
 @pytest.mark.django_db
 class TestTipForms:
-    def test_form(self, db, generate_form, generate_tip):
+    def test_form(self, db, generate_form):
         form = generate_form
         assert form.is_valid()
 
@@ -72,10 +56,14 @@ class TestTipForms:
         generate_tip.save()
         tip = get_object_or_404(Tip, pk=generate_tip.id)
         assert tip.author == AUTHOR
+        assert tip.category == CATEGORY
+        assert tip.text == TEXT
         form = generate_form
         tip = form.save(commit=False)
         tip.save()
         assert tip.author == OTHER_AUTHOR
+        assert tip.category == OTHER_CATEGORY
+        assert tip.text == OTHER_TEXT
 
     def test_bad_form(self, generate_bad_form):
         form = generate_bad_form
@@ -84,28 +72,27 @@ class TestTipForms:
 
 @pytest.mark.django_db
 class TestTipViews:
-    def test_tips_board_function_200(self, generate_get_request, generate_tip):
-        try:
-            render = board(generate_get_request)
-            assert render.status_code == 200, "status code is not 200"
-        except Exception:
-            assert False, "Error in board function"
+    def test_tips_board_function_200(self, client):
+        response = client.get('/tips/')
+        assert response.status_code == 200
+        assert 'Tips' in str(response.content)
 
     def test_tips_views_templates(self):
         try:
-            get_template('tips/board.html')
+            get_template(TIPS_PAGE_ROUTE)
         except TemplateDoesNotExist:
             assert False, f"Template {TIPS_PAGE_ROUTE} does not exist"
         try:
-            get_template('tips/add_tip.html')
+            get_template(ADD_TIP_PAGE_ROUTE)
         except TemplateDoesNotExist:
             assert False, f"Template {ADD_TIP_PAGE_ROUTE} does not exist"
         try:
-            get_template('tips/edit_tip.html')
+            get_template(EDIT_TIP_PAGE_ROUTE)
         except TemplateDoesNotExist:
             assert False, f"Template {EDIT_TIP_PAGE_ROUTE} does not exist"
 
-    def test_delete_tip_page(self, generate_get_request, generate_tip):
+    def test_delete_tip_function(self, client, generate_tip):
         generate_tip.save()
-        delete_tip(generate_get_request, generate_tip.id)
+        assert generate_tip in Tip.objects.all()
+        client.get('/tips/delete_tip/' + str(generate_tip.id) + '/')
         assert generate_tip not in Tip.objects.all()


### PR DESCRIPTION
I only changed the tests for tips_views based on https://github.com/redhat-beyond/Xpense/issues/90, https://github.com/redhat-beyond/Xpense/issues/98