### PR TITLE
Mine Page: Adding Charts Display of the Expenses

### DIFF
--- a/house/constants.py
+++ b/house/constants.py
@@ -11,3 +11,19 @@ USER_LOGIN_PAGE_ROUTE = 'registration/login.html'
 USER_SIGNUP_ROUTE = 'registration/signup.html'
 HOUSE_CREATE_ROUTE = 'house_view/house_create.html'
 MINE_EDIT_EXPENSE_ROUTE = 'house_view/edit_expense.html'
+MINE_CHARTS_ROUTE = 'house_view/mine_chart.html'
+BY_MONTH = 'date__month'
+MONTHS = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+]

--- a/house/forms.py
+++ b/house/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from expenses.models import Expenses
 from house.models import House, Job
+from datetime import datetime
 
 
 class HouseForm(forms.ModelForm):
@@ -38,3 +39,21 @@ class ExpenseForm(forms.ModelForm):
     class Meta:
         model = Expenses
         fields = ('date', 'amount', 'category', 'description')
+
+
+def get_current_year():
+    return datetime.now().year
+
+
+def get_list_of_relevant_years():
+    return [(y, y) for y in reversed(range(2020, (get_current_year() + 1)))]
+
+
+class YearFilterForm(forms.Form):
+    list_of_relevant_years = get_list_of_relevant_years()
+    year = forms.ChoiceField(
+        choices=list_of_relevant_years,
+        required=False,
+        initial=get_current_year(),
+        widget=forms.Select(attrs={'onchange': 'form.submit();'}),
+    )

--- a/static/css/app_layout.css
+++ b/static/css/app_layout.css
@@ -64,7 +64,3 @@ body {
 .fw-bolder {
   font-weight: 500 !important;
 }
-
-select {
-  display: block !important;
-}

--- a/static/css/form.css
+++ b/static/css/form.css
@@ -18,6 +18,7 @@ td input {
 
 td select {
   height: 20%;
+  display: block !important;
 }
 
 button {

--- a/static/css/house_create.css
+++ b/static/css/house_create.css
@@ -7,3 +7,7 @@
 #submit-button{
   width: 100%;
 }
+
+select {
+  display: block !important;
+}

--- a/static/css/mine.css
+++ b/static/css/mine.css
@@ -26,22 +26,30 @@
     overflow-y:scroll;
 }
 
-.btn-primary{
-  background-color: #37474f;
-  color: #fff;
-  cursor: pointer; /* Pointer/hand icon */
-  width: 12%; /* Set a width if needed */
+.chart-container {
+  text-align: justify;
+  margin-top: 1.5em;
+  width: 83%;
   position: fixed;
-  left: 87%;
-  display: block; /* Make the buttons appear below each other */
-  bottom: 32%;
-  margin: 0;
-  text-decoration: none;
-  letter-spacing: 0.5px;
+  right: 0;
+  background-color: inherit;
 }
 
 @media screen and (max-height: 450px) {
   .sidebar {
     padding-top: 15px;
   }
+}
+
+.mine-tool-bar {
+  height: 8%;
+  width: 83%;
+  text-align: justify;
+  position: fixed;
+  margin: auto;
+  display: flex;
+  justify-content: space-between;
+  bottom: 30%;
+  right: 0;
+  z-index: 9999;
 }

--- a/templates/house_view/mine_chart.html
+++ b/templates/house_view/mine_chart.html
@@ -1,0 +1,28 @@
+{% load static %}
+
+<script type="text/javascript" src="{% static 'js/random_colors.js' %}" ></script>
+<script src="{%static 'js/pie_chart.js'%}" type="text/javascript"></script>
+<script src="{%static 'js/bar_chart.js'%}" type="text/javascript"></script>
+<script>
+    $(document).ready(function () {
+        var randomColors = [{%for amount in amounts%} randomColor(),{%endfor%}];
+        var categories = [{%for category in categories%}'{{category}}',{%endfor%}];
+        var amounts = [{%for amount in amounts%}'{{amount}}',{%endfor%}];
+        create_pie_chart(categories, amounts,"Expense Amount Per Month",randomColors, "left_chart");
+        create_bar_chart(categories, amounts,"Expense Amount Per Month",randomColors, "right_chart");
+    });
+</script>
+
+
+<body>
+  <div>
+    <div class="chart_card">
+      <div class="chart_box">
+        <canvas id="left_chart"></canvas>
+      </div>
+      <div class="chart_box">
+        <canvas id="right_chart"></canvas>
+      </div>
+    </div>
+  </div>
+</body>

--- a/templates/house_view/mine_page.html
+++ b/templates/house_view/mine_page.html
@@ -1,10 +1,17 @@
-{% extends "base.html" %} {%load static%} {%block content%}
+{% extends "base.html" %} {%load static%} {% load material_form %} {%block styles%}
 <link rel="stylesheet" type="text/css" href="{% static 'css/mine.css' %}" />
+<link rel="stylesheet" type="text/css" href="{% static 'css/chart.css' %}" />
+{% endblock styles %} {%block content%}
 <body>
   <div class="sidebar-container">{% include 'house_view/sidebar.html' %}</div>
-  <div>
-      <a class="btn btn-primary" href="{% url 'house:add_expense'%}" role="button">Add Expense</a>
-      <div class="expenses_table-container">{% include 'house_view/expenses_table.html' %}</div>
+  <div class="mine-tool-bar">
+    <form method="post">
+      {% csrf_token %}
+      {% form form=form %}{% endform %}
+    </form>
+    <a class="btn" href="{% url 'house:add_expense'%}" role="button">Add Expense</a>
   </div>
+  <div class="expenses_table-container">{% include 'house_view/expenses_table.html' %}</div>
+  <div class="chart-container">{% include 'house_view/mine_chart.html' %} </div>
 </body>
 {% endblock %}

--- a/tests/my_house_tests.py
+++ b/tests/my_house_tests.py
@@ -6,11 +6,11 @@ from house.constants import (
     MINE_PAGE_ROUTE,
     MINE_SIDEBAR_ROUTE,
     MINE_EDIT_EXPENSE_ROUTE,
+    MINE_CHARTS_ROUTE,
 )
 from factories.expense import ExpenseFactory
 from factories.house import HouseFactory
 from expenses.models import Expenses
-from django.template.loader import get_template
 from tests.const import (
     EXPENSE_FORM_DATA,
     EXPENSE_BAD_FORM_DATA_DESCRIPTION,
@@ -81,20 +81,27 @@ class TestMyHouseViewsAndTemplates:
     def test_get_house_view_function_and_templates(self, client, house_factory):
         response = client.get('/house/')
         assert response.status_code == 200
-        get_template(MINE_PAGE_ROUTE)
-        get_template(MINE_EXPENSES_TABLE_ROUTE)
-        get_template(MINE_HOUSE_TABLE_ROUTE)
-        get_template(MINE_SIDEBAR_ROUTE)
+
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert MINE_PAGE_ROUTE in template_names
+        assert MINE_EXPENSES_TABLE_ROUTE in template_names
+        assert MINE_HOUSE_TABLE_ROUTE in template_names
+        assert MINE_SIDEBAR_ROUTE in template_names
+        assert MINE_CHARTS_ROUTE in template_names
 
     def test_get_add_expense_view_and_template(self, client, house_factory):
         response = client.get('/house/add_expense/')
         assert response.status_code == 200
-        get_template(MINE_ADD_EXPENSE_ROUTE)
+
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert MINE_ADD_EXPENSE_ROUTE in template_names
 
     def test_get_edit_expense_view_function_and_templates(self, client, house_factory, expense_factory):
         response = client.get('/house/edit_expense/1/')
         assert response.status_code == 200
-        get_template(MINE_EDIT_EXPENSE_ROUTE)
+
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert MINE_EDIT_EXPENSE_ROUTE in template_names
 
     def test_get_delete_expense_view(self, client, house_factory, expense_factory):
         response = client.get('/house/delete_expense/1/')


### PR DESCRIPTION
Adding the Pie and the Bar Charts to the Mine Page, which display the House expenses in another way.
The expenses are presented in the charts in the total amount, sorted by month.
Added a filter to choose which year of expenses are presented in the charts.

Addressing Issue: #102 

Screenshots of the Charts from the Mine Page:

Charts View of the Expenses:

![Mine Page - Charts View of the Expenses](https://user-images.githubusercontent.com/93318917/169768104-2f58bf48-3b16-46a4-b6bd-00304c106130.png)

New Expense shows in the charts after being added:

![Mine Page - Charts View of the Expenses - new expense added to the charts](https://user-images.githubusercontent.com/93318917/169768134-d4600999-14fc-4f38-a2ba-ce2a708e0125.png)