### PR TITLE
Vagrant: Add git install command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@
 
 # Install Pipenv, the -n option makes sudo fail instead of asking for a
 # password if we don’t have sufficient privileges to run it
+sudo -n dnf install -y git
 sudo -n dnf install -y pipenv
 cd /vagrant
 


### PR DESCRIPTION
to install django-smart-select by cloning from github it is required to have git in the virtual machine along pipenv this adds the installation of git to the setup script